### PR TITLE
Fix incorrect naming of archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ CMakeLists.txt.user
 /*build
 .vs
 CMakeSettings.json
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,13 +120,6 @@ target_link_directories(${PROJ_NAME}
 	PRIVATE
 		${LIBBSARCH_ROOT})
 
-message("Default path is: ${default_project_path}")
-message("Project path is: ${project_path}")
-message("Lib path is: ${lib_path}")
-message("packer path is ${CMAKE_SOURCE_DIR}/include/bsapacker")
-message("boost di root is ${BOOST_DI_ROOT}")
-message("libbsarch root is ${LIBBSARCH_ROOT}")
-
 target_link_libraries(${PROJ_NAME}
 	PUBLIC
 		Qt5::Widgets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,13 @@ target_link_directories(${PROJ_NAME}
 	PRIVATE
 		${LIBBSARCH_ROOT})
 
+message("Default path is: ${default_project_path}")
+message("Project path is: ${project_path}")
+message("Lib path is: ${lib_path}")
+message("packer path is ${CMAKE_SOURCE_DIR}/include/bsapacker")
+message("boost di root is ${BOOST_DI_ROOT}")
+message("libbsarch root is ${LIBBSARCH_ROOT}")
+
 target_link_libraries(${PROJ_NAME}
 	PUBLIC
 		Qt5::Widgets

--- a/include/bsapacker/IPackerDialog.h
+++ b/include/bsapacker/IPackerDialog.h
@@ -13,6 +13,7 @@ namespace BsaPacker
 
 	public:
 		virtual ~IPackerDialog() override = default;
+		[[nodiscard]] virtual bool IsNewFilename() const = 0;
 		[[nodiscard]] virtual QString SelectedMod() const = 0;
 		virtual void RefreshModList() = 0;
 		[[nodiscard]] virtual QString SelectedPluginItem() const = 0;

--- a/include/bsapacker/ModDtoFactory.h
+++ b/include/bsapacker/ModDtoFactory.h
@@ -13,10 +13,13 @@ namespace BsaPacker
 		ModDtoFactory(const IModContext* modContext);
 		~ModDtoFactory() override = default;
 		[[nodiscard]] std::unique_ptr<IModDto> Create() const override;
-		[[nodiscard]] static QString ArchiveNameValidator(const QString& modName,
-											const QString& pluginName);
-		[[nodiscard]] static bool CanOverwriteFile(const QString& filePath,
-											 const QString& fileName);
+		[[nodiscard]] static QString ArchiveNameValidator(
+			const QString& modName,
+			const QString& pluginName,
+			const bool needsNewName);
+		[[nodiscard]] static bool CanOverwriteFile(
+			const QString& filePath,
+			const QString& fileName);
 
 	private:
 		const IModContext* m_ModContext = nullptr;

--- a/src/ArchiveNameService.cpp
+++ b/src/ArchiveNameService.cpp
@@ -28,7 +28,7 @@ namespace BsaPacker
 
 	QString ArchiveNameService::GetArchiveFullPath(const bsa_archive_type_e type, const IModDto* modDto) const
 	{
-		return modDto->Directory() + '/' + modDto->ModForename() + this->Infix(type) + this->GetFileExtension();
+		return modDto->Directory() + '/' + modDto->ArchiveName() + this->Infix(type) + this->GetFileExtension();
 	}
 
 	QString ArchiveNameService::Infix(const bsa_archive_type_e type) const

--- a/src/ModDtoFactory.cpp
+++ b/src/ModDtoFactory.cpp
@@ -29,7 +29,8 @@ namespace BsaPacker
 		const QString& modName = packerDialog.SelectedMod();
 		const QString& modDir = this->m_ModContext->GetAbsoluteModPath(modName);
 		const QString& pluginName = packerDialog.SelectedPluginItem();
-		const QString& archiveName = ModDtoFactory::ArchiveNameValidator(modName, pluginName);
+		const bool needsNewName = packerDialog.IsNewFilename();
+		const QString& archiveName = ModDtoFactory::ArchiveNameValidator(modName, pluginName, needsNewName);
 		const QString& archiveExtension = nexusId == FALLOUT_4_NEXUS_ID
 				? QStringLiteral(".ba2")
 				: QStringLiteral(".bsa");
@@ -37,11 +38,12 @@ namespace BsaPacker
 		return std::make_unique<ModDto>(nexusId, modDir, archiveName, archiveExtension);
 	}
 
-	QString ModDtoFactory::ArchiveNameValidator(const QString& modName, const QString& pluginName)
+	QString ModDtoFactory::ArchiveNameValidator(
+		const QString& modName,
+		const QString& pluginName,
+		const bool needsNewName)
 	{
 		QString archive_name_base;
-		// check if it is the "new filename" text
-		const bool needsNewName = !static_cast<bool>(QString::compare(pluginName.chopped(4), QStringLiteral("<new filename>")));
 		if (needsNewName) {
 			bool ok = false;
 			const QString& name = QInputDialog::getText(nullptr,

--- a/src/PackerDialog.cpp
+++ b/src/PackerDialog.cpp
@@ -49,7 +49,7 @@ namespace BsaPacker
 
 	bool PackerDialog::IsNewFilename() const
 	{
-		const int currentIndex = this->listArchiveNames.currentIndex().row();
+		const int currentIndex = this->listArchiveNames.currentIndex().row() + 1;
 		const int count = this->listArchiveNames.count();
 		return currentIndex == count;
 	}

--- a/src/PackerDialog.cpp
+++ b/src/PackerDialog.cpp
@@ -47,6 +47,13 @@ namespace BsaPacker
 		QObject::connect(&comboModList, qOverload<const QString&>(&QComboBox::currentTextChanged), [this](auto&& text) { this->UpdateNameList(text); });
 	}
 
+	bool PackerDialog::IsNewFilename() const
+	{
+		const int currentIndex = this->listArchiveNames.currentIndex().row();
+		const int count = this->listArchiveNames.count();
+		return currentIndex == count;
+	}
+
 	QString PackerDialog::SelectedMod() const
 	{
 		return this->comboModList.currentText();

--- a/src/PackerDialog.h
+++ b/src/PackerDialog.h
@@ -22,6 +22,7 @@ namespace BsaPacker
 		~PackerDialog() override = default;
 
 		// IPackerDialog interface
+		[[nodiscard]] bool IsNewFilename() const override;
 		void RefreshModList() override;
 		[[nodiscard]] QString SelectedMod() const override;
 		[[nodiscard]] QString SelectedPluginItem() const override;

--- a/src/bsa_packer_en.ts
+++ b/src/bsa_packer_en.ts
@@ -18,17 +18,17 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="ModDtoFactory.cpp" line="49"/>
+        <location filename="ModDtoFactory.cpp" line="51"/>
         <source>Archive name (no file extension):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ModDtoFactory.cpp" line="72"/>
+        <location filename="ModDtoFactory.cpp" line="74"/>
         <source>File &quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ModDtoFactory.cpp" line="72"/>
+        <location filename="ModDtoFactory.cpp" line="74"/>
         <source>&quot; already exists. Overwrite?</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This should fix the issue where a user would always have the name of the mod be the name of the created archive.