### PR TITLE
Only build tests if BUILD_TESTING is True.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,4 +18,6 @@ target_link_libraries(bsa_packer DirectXTex)
 requires_library(libbsarch)
 target_compile_definitions(bsa_packer PRIVATE BSAPACKER_LIBRARY)
 
+if(BUILD_TESTING)
 add_subdirectory(tests)
+endif()


### PR DESCRIPTION
There are many mocking classes in the tests project that must be updated every time the interface in `uibase` are updated. This is kind of annoying, and almost useless since these tests are never run automatically at any point.

This makes it so the test project is not built unless `BUILD_TESTING` is `On` in CMake. The mock classes will be out-of-date but that does not need fixing until someone actually wants to run the tests.