### PR TITLE
Support TTW, Enderal, and EnderalSE

### DIFF
--- a/src/ArchiveBuilderFactory.cpp
+++ b/src/ArchiveBuilderFactory.cpp
@@ -23,8 +23,10 @@ namespace BsaPacker
 			case NexusId::Fallout3:
 			case NexusId::NewVegas:
 			case NexusId::Skyrim:
+			case NexusId::Enderal:
 				return std::vector<bsa_archive_type_e> { baFO3 };
 			case NexusId::SkyrimSE:
+			case NexusId::EnderalSE:
 				return std::vector<bsa_archive_type_e> { baSSE };
 			case NexusId::Fallout4:
 			case NexusId::Starfield:

--- a/src/ArchiveNameService.cpp
+++ b/src/ArchiveNameService.cpp
@@ -18,6 +18,8 @@ namespace BsaPacker
 		case NexusId::NewVegas:
 		case NexusId::Skyrim:
 		case NexusId::SkyrimSE:
+		case NexusId::Enderal:
+		case NexusId::EnderalSE:
 			return QStringLiteral(".bsa");
 		case NexusId::Fallout4:
 		case  NexusId::Starfield:

--- a/src/DummyPluginServiceFactory.cpp
+++ b/src/DummyPluginServiceFactory.cpp
@@ -36,8 +36,10 @@ namespace BsaPacker
 			case NexusId::NewVegas:
 				return std::make_unique<NewVegasDummyPluginService>(m_FileWriterService, m_DummyPluginLogic);
 			case NexusId::Skyrim:
+			case NexusId::Enderal:
 				return std::make_unique<SkyrimDummyPluginService>(m_FileWriterService, m_DummyPluginLogic);
 			case NexusId::SkyrimSE:
+			case NexusId::EnderalSE:
 				return std::make_unique<SkyrimSEDummyPluginService>(m_FileWriterService, m_DummyPluginLogic);
 			case NexusId::Fallout4:
 				return std::make_unique<Fallout4DummyPluginService>(m_FileWriterService, m_DummyPluginLogic);

--- a/src/ModContext.cpp
+++ b/src/ModContext.cpp
@@ -26,7 +26,19 @@ namespace BsaPacker
 	int ModContext::GetNexusId() const
 	{
 		const MOBase::IPluginGame* managedGame = this->m_Organizer->managedGame();
-		return managedGame->nexusGameID();
+		int nexusId = managedGame->nexusGameID();
+
+		// Games with no Nexus page have an ID of 0. Use primarySources in that case
+		if (nexusId != 0) {
+			return nexusId;
+		}
+		if (!managedGame->primarySources().isEmpty()) {
+			QString primarySource = managedGame->primarySources().first();
+			if (primarySource == "FalloutNV") { // TTW
+				return NexusId::NewVegas;
+			}
+		}		
+		return nexusId;
 	}
 
 	QStringList ModContext::GetPlugins(const QDir& modDirectory) const

--- a/src/NexusId.h
+++ b/src/NexusId.h
@@ -5,6 +5,7 @@ namespace BsaPacker
 {
 	enum NexusId
 	{
+		// Skyrim VR, Fallout 4 VR, and TTW don't have Nexus pages so are 0
 		Morrowind = 100,
 		Oblivion = 101,
 		Fallout3 = 120,
@@ -12,6 +13,8 @@ namespace BsaPacker
 		Skyrim = 110,
 		SkyrimSE = 1704,
 		Fallout4 = 1151,
+		Enderal = 2736,
+		EnderalSE = 3685,
 		Starfield = 4187
 	};
 } // namespace BsaPacker


### PR DESCRIPTION
This allows TTW, Enderal, and EnderalSE instances to create archives. Games that do not have a dedicated Nexus portal (TTW) are given a nexusGameID of 0, so we can use primarySources to identify them. TTW will use the NewVegas ID since it uses the same archive format.

The Enderal nexusGameID currently returns 0, but I have made a request to change it.

I did not add Nehrim, Skyrim VR, or Fallout 4 VR because I do not know for sure if they use the same formats as their base games. I can add them if it is confirmed that they use one of the supported formats.