### PR TITLE
Add setting for archive compression

### DIFF
--- a/src/ArchiveBuilderHelper.cpp
+++ b/src/ArchiveBuilderHelper.cpp
@@ -48,6 +48,10 @@ namespace BsaPacker
 
 	bool ArchiveBuilderHelper::isIncompressible(const path& filename) const
 	{
+		if (!this->m_SettingsService->GetPluginSetting(SettingsService::SETTING_COMPRESS_ARCHIVES).toBool()) {
+			return true;
+		}
+
 		const auto& extension = filename.extension().string();
 		const auto& count = ArchiveBuilderHelper::INCOMPRESSIBLE_TYPES.count(extension);
 		const auto& result = count > 0;

--- a/src/SettingsService.cpp
+++ b/src/SettingsService.cpp
@@ -5,12 +5,14 @@ namespace BsaPacker
 	const QString& SettingsService::SETTING_HIDE_LOOSE_ASSETS = QStringLiteral("hide_loose_assets");
 	const QString& SettingsService::SETTING_CREATE_PLUGINS = QStringLiteral("create_plugins");
 	const QString& SettingsService::SETTING_BLACKLISTED_FILES = QStringLiteral("blacklisted_files");
+	const QString& SettingsService::SETTING_COMPRESS_ARCHIVES = QStringLiteral("compress_archives");
 	//const QString& SettingsService::SETTING_SPLIT_ARCHIVES = "split_archives";
 
 	const QList<MOBase::PluginSetting>& SettingsService::PluginSettings = {
 		MOBase::PluginSetting(SettingsService::SETTING_HIDE_LOOSE_ASSETS, QObject::tr("After creating the archive, set loose assets to hidden."), false),
 		MOBase::PluginSetting(SettingsService::SETTING_CREATE_PLUGINS, QObject::tr("Create a dummy plugin to load the archive if one does not exist."), false),
-		MOBase::PluginSetting(SettingsService::SETTING_BLACKLISTED_FILES, QObject::tr("Specify a semi-colon seperated list of file extensions to ignore when packing."), ".txt;.hkx;.xml;.ini;.bk2")
+		MOBase::PluginSetting(SettingsService::SETTING_BLACKLISTED_FILES, QObject::tr("Specify a semi-colon seperated list of file extensions to ignore when packing."), ".txt;.hkx;.xml;.ini;.bk2"),
+		MOBase::PluginSetting(SettingsService::SETTING_COMPRESS_ARCHIVES, QObject::tr("Compress archives if they do not contain incompressible files."), true)
 		//MOBase::PluginSetting(SettingsService::SETTING_SPLIT_ARCHIVES, QObject::tr("Automatically create multiple archives if they exceed the size limit."), false);
 	};
 

--- a/src/SettingsService.h
+++ b/src/SettingsService.h
@@ -19,6 +19,7 @@ namespace BsaPacker
 		static const QString& SETTING_HIDE_LOOSE_ASSETS;
 		static const QString& SETTING_CREATE_PLUGINS;
 		static const QString& SETTING_BLACKLISTED_FILES;
+		static const QString& SETTING_COMPRESS_ARCHIVES;
 		//static const QString& SETTING_SPLIT_ARCHIVES;
 
 		static const QList<MOBase::PluginSetting>& PluginSettings;


### PR DESCRIPTION
Adds a setting to choose whether archives are compressed or not. Compression is skipped if certain file types are present, so this is for the case where an archive does not contain incompressible types. The primary use is for games such as Fallout: New Vegas where uncompressed BSAs have better performance.