### PR TITLE
Create .override dialog for Fallout 3 and New Vegas

### DIFF
--- a/src/BsaPacker.cpp
+++ b/src/BsaPacker.cpp
@@ -12,6 +12,7 @@
 #include "HideLooseAssetService.h"
 #include "ModContext.h"
 #include "ModDto.h"
+#include "OverrideFileService.h"
 #include "PackerDialog.h"
 #include "SettingsService.h"
 #include <bsapacker/ModDtoFactory.h>
@@ -85,7 +86,8 @@ namespace BsaPacker
 			di::bind<IArchiveNameService>.to<ArchiveNameService>(),
 			di::bind<IDummyPluginLogic>.to<DummyPluginLogic>(),
 			di::bind<IHideLooseAssetService>.to<HideLooseAssetService>(),
-			di::bind<IPackerDialog>.to<PackerDialog>()
+			di::bind<IPackerDialog>.to<PackerDialog>(),
+			di::bind<IOverrideFileService>.to<OverrideFileService>()
 		);
 
 		BsaPackerWorker worker = di::create<BsaPackerWorker>(injector);

--- a/src/BsaPackerWorker.cpp
+++ b/src/BsaPackerWorker.cpp
@@ -14,14 +14,16 @@ namespace BsaPacker
 		const IArchiveAutoService* archiveAutoService,
 		const IDummyPluginServiceFactory* dummyPluginServiceFactory,
 		const IHideLooseAssetService* hideLooseAssetService,
-		const IArchiveNameService* archiveNameService) :
+		const IArchiveNameService* archiveNameService,
+		const IOverrideFileService* overrideFileService) :
 		m_SettingsService(settingsService),
 		m_ModDtoFactory(modDtoFactory),
 		m_ArchiveBuilderFactory(archiveBuilderFactory),
 		m_ArchiveAutoService(archiveAutoService),
 		m_DummyPluginServiceFactory(dummyPluginServiceFactory),
 		m_HideLooseAssetService(hideLooseAssetService),
-		m_ArchiveNameService(archiveNameService)
+		m_ArchiveNameService(archiveNameService),
+		m_OverrideFileService(overrideFileService)
 	{
 	}
 
@@ -43,6 +45,8 @@ namespace BsaPacker
 		}
 		const std::unique_ptr<IDummyPluginService> pluginService = this->m_DummyPluginServiceFactory->Create();
 		pluginService->CreatePlugin(modDto->Directory(), modDto->ArchiveName());
+
+		this->m_OverrideFileService->CreateOverrideFile(modDto->NexusId(), modDto->Directory(), modDto->ArchiveName());
 
 		if (!modDto->Directory().isEmpty()) {
 			this->m_HideLooseAssetService->HideLooseAssets(modDto->Directory());

--- a/src/BsaPackerWorker.h
+++ b/src/BsaPackerWorker.h
@@ -9,6 +9,7 @@
 #include <bsapacker/IDummyPluginServiceFactory.h>
 #include <bsapacker/IHideLooseAssetService.h>
 #include <bsapacker/IArchiveNameService.h>
+#include <bsapacker/IOverrideFileService.h>
 
 namespace BsaPacker
 {
@@ -22,7 +23,8 @@ namespace BsaPacker
 			const IArchiveAutoService* archiveAutoService,
 			const IDummyPluginServiceFactory* dummyPluginService,
 			const IHideLooseAssetService* hideLooseAssetService,
-			const IArchiveNameService* archiveNameService);
+			const IArchiveNameService* archiveNameService,
+			const IOverrideFileService* overrideFileService);
 		void DoWork() const;
 
 	private:
@@ -33,6 +35,7 @@ namespace BsaPacker
 		const IDummyPluginServiceFactory* m_DummyPluginServiceFactory = nullptr;
 		const IHideLooseAssetService* m_HideLooseAssetService = nullptr;
 		const IArchiveNameService* m_ArchiveNameService = nullptr;
+		const IOverrideFileService* m_OverrideFileService = nullptr;
 	};
 }
 

--- a/src/OverrideFileService.cpp
+++ b/src/OverrideFileService.cpp
@@ -1,0 +1,36 @@
+#include "OverrideFileService.h"
+
+#include <questionboxmemory.h>
+#include <QApplication>
+#include <QDialogButtonBox>
+
+namespace BsaPacker {
+	const uint16_t FALLOUT_3_NEXUS_ID = 120;
+	const uint16_t NEW_VEGAS_NEXUS_ID = 130;
+
+	OverrideFileService::OverrideFileService(
+		const IFileWriterService* fileWriterService)
+		: m_FileWriterService(fileWriterService)
+	{
+	}
+
+	// TODO: Add detection for Command Extender and JIP LN NVSE and warn if missing
+	bool OverrideFileService::CreateOverrideFile(const int nexusId,
+		const QString& modPath,
+		const QString& archiveNameBase) const {
+
+		if (nexusId != FALLOUT_3_NEXUS_ID && nexusId != NEW_VEGAS_NEXUS_ID) {
+			return false;
+		}
+
+		if (MOBase::QuestionBoxMemory::query(QApplication::activeModalWidget(), "BSAPacker", "Create .override file?",
+			"Do you want to create an override file for the archive?",
+			QDialogButtonBox::No | QDialogButtonBox::Yes, QDialogButtonBox::No) & QDialogButtonBox::No) {
+			return false;
+		}
+
+		const QString& fileNameNoExtension = modPath + '/' + archiveNameBase;
+		const std::string& absoluteFileName = fileNameNoExtension.toStdString() + ".override";
+		return this->m_FileWriterService->Write(absoluteFileName, nullptr, 0);
+	}
+} // namespace BsaPacker

--- a/src/OverrideFileService.h
+++ b/src/OverrideFileService.h
@@ -1,0 +1,21 @@
+#ifndef OVERRIDEFILESERVICE_H
+#define OVERRIDEFILESERVICE_H
+
+#include "bsapacker_global.h"
+#include <bsapacker/IFileWriterService.h>
+#include <bsapacker/IOverrideFileService.h>
+
+namespace BsaPacker {
+	class BSAPACKER_EXPORT OverrideFileService : public IOverrideFileService {
+	public:
+		OverrideFileService(const IFileWriterService* fileWriterService);
+		bool CreateOverrideFile(const int nexusId,
+			const QString& modPath,
+			const QString& archiveNameBase) const override;
+
+	private:
+		const IFileWriterService* m_FileWriterService = nullptr;
+	};
+} // namespace BsaPacker
+
+#endif // OVERRIDEFILESERVICE_H

--- a/src/bsapacker/IOverrideFileService.h
+++ b/src/bsapacker/IOverrideFileService.h
@@ -1,0 +1,16 @@
+#ifndef IOVERRIDEFILESERVICE_H
+#define IOVERRIDEFILESERVICE_H
+
+#include <QString>
+
+namespace BsaPacker {
+	class IOverrideFileService {
+	public:
+		virtual ~IOverrideFileService() = default;
+		virtual bool CreateOverrideFile(const int nexusId,
+			const QString& modPath,
+			const QString& archiveNameBase) const = 0;
+	};
+} // namespace BsaPacker
+
+#endif // IOVERRIDEFILESERVICE_H


### PR DESCRIPTION
This adds a dialog that prompts the user to create a .override when packing a New Vegas or Fallout 3 mod. This file makes the associated BSA win file conflicts against previously loaded BSAs. This functionality is added by JIP LN NVSE for New Vegas and Command Extender for Fallout 3.

I am open to suggestions to improve how this option is displayed to the user.
A possible improvement is displaying a warning if the user does not have the required mod or if the archive includes a file or folder that cannot be overridden as described by this page https://geckwiki.com/index.php?title=BSA_Files