### PR TITLE
Avoid is_directory check for increased performance

### DIFF
--- a/src/ArchiveBuilderHelper.cpp
+++ b/src/ArchiveBuilderHelper.cpp
@@ -7,7 +7,6 @@
 
 #include <QDebug>
 
-using std::filesystem::is_directory;
 using std::filesystem::path;
 using std::filesystem::directory_entry;
 using std::filesystem::directory_iterator;
@@ -25,7 +24,9 @@ namespace BsaPacker
 	{
 		uint32_t count = 0;
 		for(auto& p : recursive_directory_iterator(rootDirectory)) {
-			count++;
+			if (p.is_regular_file()) {
+				count++;
+			}
 		}
 		return count;
 	}
@@ -42,7 +43,6 @@ namespace BsaPacker
 	bool ArchiveBuilderHelper::isFileIgnorable(const path& filepath, const std::vector<path::string_type>& rootDirFilenames) const
 	{
 		return this->doesPathContainFiles(filepath, rootDirFilenames) || // ignore files within mod directory
-			is_directory(filepath) || // ignore directories
 			this->isExtensionBlacklisted(filepath); // ignore user blacklisted file types
 	}
 

--- a/src/GeneralArchiveBuilder.cpp
+++ b/src/GeneralArchiveBuilder.cpp
@@ -25,7 +25,7 @@ namespace BsaPacker
 		const auto& rootDirFiles = this->m_ArchiveBuilderHelper->getRootDirectoryFilenames(dirString);
 		qDebug() << "root is: " << m_RootDirectory.path() + '/';
 
-		QDirIterator iterator(this->m_RootDirectory, QDirIterator::Subdirectories);
+		QDirIterator iterator(this->m_RootDirectory.absolutePath(), QDir::Files, QDirIterator::Subdirectories);
 		while (iterator.hasNext()) {
 			QApplication::processEvents();
 

--- a/src/TextureArchiveBuilder.cpp
+++ b/src/TextureArchiveBuilder.cpp
@@ -26,7 +26,7 @@ namespace BsaPacker
 		const auto& rootDirFiles = this->m_ArchiveBuilderHelper->getRootDirectoryFilenames(dirString);
 		qDebug() << "root is: " << m_RootDirectory.path() + '/';
 
-		QDirIterator iterator(this->m_RootDirectory, QDirIterator::Subdirectories);
+		QDirIterator iterator(this->m_RootDirectory.absolutePath(), QDir::Files, QDirIterator::Subdirectories);
 		while (iterator.hasNext()) {
 			QApplication::processEvents();
 

--- a/src/TexturelessArchiveBuilder.cpp
+++ b/src/TexturelessArchiveBuilder.cpp
@@ -25,7 +25,7 @@ namespace BsaPacker
 		const auto& rootDirFiles = this->m_ArchiveBuilderHelper->getRootDirectoryFilenames(dirString);
 		qDebug() << "root is: " << m_RootDirectory.path() + '/';
 
-		QDirIterator iterator(this->m_RootDirectory, QDirIterator::Subdirectories);
+		QDirIterator iterator(this->m_RootDirectory.absolutePath(), QDir::Files, QDirIterator::Subdirectories);
 		while (iterator.hasNext()) {
 			QApplication::processEvents();
 


### PR DESCRIPTION
This change makes the iterator in setFiles only consider files so we can get rid of the is_directory check in isFileIgnorable. I tested with the mod Fallout - The Frontier which has over 47,000 files and 2,000 directories. Using TimeThis, the time for setFiles decreased from about 16 seconds to 1.5 seconds on average.