### PR TITLE
Split archives at size limits

### DIFF
--- a/src/ArchiveNameService.cpp
+++ b/src/ArchiveNameService.cpp
@@ -2,6 +2,8 @@
 
 #include "NexusId.h"
 
+#include <QFileInfo>
+
 namespace BsaPacker
 {
 	ArchiveNameService::ArchiveNameService(const IModContext* modContext)
@@ -31,7 +33,9 @@ namespace BsaPacker
 
 	QString ArchiveNameService::GetArchiveFullPath(const bsa_archive_type_e type, const IModDto* modDto) const
 	{
-		return QDir::toNativeSeparators(modDto->Directory() + '/' + modDto->ArchiveName() + this->Infix(type) + this->GetFileExtension());
+		const QString& pathNoExt(QDir::toNativeSeparators(modDto->Directory() + '/' + modDto->ArchiveName() + this->Infix(type)));
+		const QString& suffix = this->Suffix(pathNoExt);
+		return QDir::toNativeSeparators(pathNoExt + suffix + this->GetFileExtension());
 	}
 
 	QString ArchiveNameService::Infix(const bsa_archive_type_e type) const
@@ -49,5 +53,19 @@ namespace BsaPacker
 		default:
 			return QString();
 		};
+	}
+
+	QString ArchiveNameService::Suffix(const QString& pathNoExt) const {
+		int archiveIndex = 0;
+		const QString& fileExt = this->GetFileExtension();
+		QFileInfo fileInfo(pathNoExt + fileExt);
+		while (fileInfo.exists()) {
+			++archiveIndex;
+			fileInfo.setFile(pathNoExt + QString::number(archiveIndex) + fileExt);
+		}
+		if (archiveIndex != 0) {
+			return QString::number(archiveIndex);
+		}
+		return QString();
 	}
 }

--- a/src/ArchiveNameService.cpp
+++ b/src/ArchiveNameService.cpp
@@ -55,6 +55,8 @@ namespace BsaPacker
 		};
 	}
 
+	// gets the number to append when there are multiple archives
+	// a way to avoid overwriting any existing files
 	QString ArchiveNameService::Suffix(const QString& pathNoExt) const {
 		int archiveIndex = 0;
 		const QString& fileExt = this->GetFileExtension();

--- a/src/ArchiveNameService.h
+++ b/src/ArchiveNameService.h
@@ -15,9 +15,9 @@ namespace BsaPacker
 		QString GetArchiveFullPath(bsa_archive_type_e type, const IModDto* modDto) const override;
 		QString GetFileExtension() const override;
 		QString Infix(bsa_archive_type_e type) const override;
+		QString Suffix(const QString& pathNoExt) const override;
 	private:
 		const IModContext* m_ModContext = nullptr;
-
 	};
 }
 

--- a/src/BsaPackerWorker.cpp
+++ b/src/BsaPackerWorker.cpp
@@ -39,23 +39,23 @@ namespace BsaPacker
 			const std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> archives = builder->getArchives();
 			for (const auto& archive : archives) {
 				if (archive) {
-					const QString& archiveFullPath = this->m_ArchiveNameService->GetArchiveFullPath(type, modDto.get());
-					bool res = this->m_ArchiveAutoService->CreateBSA(archive.get(), archiveFullPath, type);
+					const QFileInfo fileInfo(this->m_ArchiveNameService->GetArchiveFullPath(type, modDto.get()));
+					bool res = this->m_ArchiveAutoService->CreateBSA(archive.get(), fileInfo.absoluteFilePath(), type);
 					if (res) {
-						createdArchives.append(QFileInfo(archiveFullPath).fileName());
+						createdArchives.append(fileInfo.baseName());
 					}
 				}
 			}
 		}
 
 		if (!createdArchives.isEmpty()) {
-			QMessageBox::information(nullptr, "", QObject::tr("Created archive(s):") + "\n" + createdArchives.join(",\n"));
+			QMessageBox::information(nullptr, "",
+        QObject::tr("Created archive(s):") + "\n" + createdArchives.join(modDto->ArchiveExtension() +",\n") + modDto->ArchiveExtension());
+			this->m_OverrideFileService->CreateOverrideFile(modDto->NexusId(), modDto->Directory(), createdArchives);
 		}
 
 		const std::unique_ptr<IDummyPluginService> pluginService = this->m_DummyPluginServiceFactory->Create();
 		pluginService->CreatePlugin(modDto->Directory(), modDto->ArchiveName());
-
-		this->m_OverrideFileService->CreateOverrideFile(modDto->NexusId(), modDto->Directory(), modDto->ArchiveName());
 
 		if (!modDto->Directory().isEmpty()) {
 			this->m_HideLooseAssetService->HideLooseAssets(modDto->Directory());

--- a/src/BsaPackerWorker.cpp
+++ b/src/BsaPackerWorker.cpp
@@ -29,20 +29,29 @@ namespace BsaPacker
 
 	void BsaPackerWorker::DoWork() const
 	{
+		QStringList createdArchives;
 		const std::unique_ptr<IModDto> modDto = this->m_ModDtoFactory->Create(); // handles PackerDialog and validation, implements Null Object pattern
 		const std::vector<bsa_archive_type_e> types = this->m_ArchiveBuilderFactory->GetArchiveTypes(modDto.get());
 		for (auto&& type : types) {
 			const std::unique_ptr<IArchiveBuilder> builder = this->m_ArchiveBuilderFactory->Create(type, modDto.get());
 			ArchiveBuildDirector director(this->m_SettingsService, builder.get());
 			director.Construct(); // must check if cancelled
-			const std::unique_ptr<libbsarch::bs_archive_auto> archive = builder->getArchive();
-			if (archive) {
-				const QString& archiveFullPath = this->m_ArchiveNameService->GetArchiveFullPath(type, modDto.get());
-				bool res = this->m_ArchiveAutoService->CreateBSA(archive.get(), archiveFullPath, type);
-				if (res)
-					QMessageBox::information(nullptr, "", QObject::tr("Created") + " \"" + archiveFullPath + "\"");
+			const std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> archives = builder->getArchives();
+			for (const auto& archive : archives) {
+				if (archive) {
+					const QString& archiveFullPath = this->m_ArchiveNameService->GetArchiveFullPath(type, modDto.get());
+					bool res = this->m_ArchiveAutoService->CreateBSA(archive.get(), archiveFullPath, type);
+					if (res) {
+						createdArchives.append(QFileInfo(archiveFullPath).fileName());
+					}
+				}
 			}
 		}
+
+		if (!createdArchives.isEmpty()) {
+			QMessageBox::information(nullptr, "", QObject::tr("Created archive(s):") + "\n" + createdArchives.join(",\n"));
+		}
+
 		const std::unique_ptr<IDummyPluginService> pluginService = this->m_DummyPluginServiceFactory->Create();
 		pluginService->CreatePlugin(modDto->Directory(), modDto->ArchiveName());
 

--- a/src/GeneralArchiveBuilder.cpp
+++ b/src/GeneralArchiveBuilder.cpp
@@ -9,11 +9,14 @@ using namespace libbsarch;
 
 namespace BsaPacker
 {
+	// 2 GiB limit. This does not consider size after compression or share data
+	const qint64 GeneralArchiveBuilder::SIZE_LIMIT = (qint64)1024 * 1024 * 1024 * 2;
+
 	GeneralArchiveBuilder::GeneralArchiveBuilder(const IArchiveBuilderHelper* archiveBuilderHelper, const QDir& rootDir, const bsa_archive_type_t& type)
-		: m_ArchiveBuilderHelper(archiveBuilderHelper), m_RootDirectory(rootDir)
+		: m_ArchiveBuilderHelper(archiveBuilderHelper), m_RootDirectory(rootDir), m_ArchiveType(type)
 	{
 		this->m_Cancelled = false;
-		this->m_Archive = std::make_unique<libbsarch::bs_archive_auto>(type);
+		this->m_Archives.emplace_back(std::make_unique<libbsarch::bs_archive_auto>(this->m_ArchiveType));
 	}
 
 	uint32_t GeneralArchiveBuilder::setFiles()
@@ -21,6 +24,7 @@ namespace BsaPacker
 		uint32_t incompressibleFiles = 0;
 		uint32_t compressibleFiles = 0;
 		int count = 0;
+		qint64 currentSize = 0;
 		const auto& dirString = (this->m_RootDirectory.path() + '/').toStdWString();
 		const auto& rootDirFiles = this->m_ArchiveBuilderHelper->getRootDirectoryFilenames(dirString);
 		qDebug() << "root is: " << m_RootDirectory.path() + '/';
@@ -30,11 +34,14 @@ namespace BsaPacker
 			QApplication::processEvents();
 
 			if (this->m_Cancelled) {
-				this->m_Archive.reset();
+				for (auto& archive : this->m_Archives) {
+					archive.reset();
+				}
 				return 0;
 			}
 
-			const QString& filepath = iterator.next();
+			const QFileInfo& fileInfo = iterator.nextFileInfo();
+			const QString& filepath = fileInfo.absoluteFilePath();
 			const bool ignored = this->m_ArchiveBuilderHelper->isFileIgnorable(filepath.toStdWString(), rootDirFiles);
 
 			Q_EMIT this->valueChanged(++count);
@@ -42,25 +49,35 @@ namespace BsaPacker
 				continue;
 			}
 
+			currentSize += fileInfo.size();
+			if (currentSize > SIZE_LIMIT) {
+				currentSize = fileInfo.size();
+				this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
+				incompressibleFiles = 0;
+				compressibleFiles = 0;
+				this->m_Archives.emplace_back(std::make_unique<libbsarch::bs_archive_auto>(this->m_ArchiveType));
+				this->setShareData(true);
+			}
+
 			this->m_ArchiveBuilderHelper->isIncompressible(filepath.toStdWString()) ? ++incompressibleFiles : ++compressibleFiles;
 			auto fileBlob = disk_blob(
 				 dirString,
 				 filepath.toStdWString());
-			this->m_Archive->add_file_from_disk(fileBlob);
+			this->m_Archives.back()->add_file_from_disk(fileBlob);
 			qDebug() << "file is: " << filepath;
 		}
-		this->m_Archive->set_compressed(!static_cast<bool>(incompressibleFiles));
+		this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
 		return incompressibleFiles + compressibleFiles;
 	}
 
 	void GeneralArchiveBuilder::setShareData(const bool value)
 	{
-		this->m_Archive->set_share_data(value);
+		this->m_Archives.back()->set_share_data(value);
 	}
 
-	std::unique_ptr<libbsarch::bs_archive_auto> GeneralArchiveBuilder::getArchive()
+	std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> GeneralArchiveBuilder::getArchives()
 	{
-		return std::move(this->m_Archive);
+		return std::move(this->m_Archives);
 	}
 
 	uint32_t GeneralArchiveBuilder::getFileCount() const

--- a/src/ModContext.cpp
+++ b/src/ModContext.cpp
@@ -59,7 +59,7 @@ namespace BsaPacker
 		const MOBase::IModList* const list = m_Organizer->modList();
 		const std::function<bool(const QString&)> modStateValid = [&](const QString& mod)
 		{
-			return list->state(mod) & MOBase::IModList::STATE_VALID;
+			return !mod.endsWith("_separator", Qt::CaseInsensitive) && (list->state(mod) & MOBase::IModList::STATE_VALID);
 		};
 		return QtConcurrent::blockingFiltered(list->allMods(), modStateValid);
 	}

--- a/src/NullArchiveBuilder.cpp
+++ b/src/NullArchiveBuilder.cpp
@@ -11,9 +11,9 @@ namespace BsaPacker
 	{
 	}
 
-	std::unique_ptr<libbsarch::bs_archive_auto> NullArchiveBuilder::getArchive()
+	std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> NullArchiveBuilder::getArchives()
 	{
-		return nullptr;
+		return {};
 	}
 
 	uint32_t NullArchiveBuilder::getFileCount() const

--- a/src/OverrideFileService.cpp
+++ b/src/OverrideFileService.cpp
@@ -17,20 +17,28 @@ namespace BsaPacker {
 	// TODO: Add detection for Command Extender and JIP LN NVSE and warn if missing
 	bool OverrideFileService::CreateOverrideFile(const int nexusId,
 		const QString& modPath,
-		const QString& archiveNameBase) const {
+		const QStringList& archiveNames) const {
 
 		if (nexusId != FALLOUT_3_NEXUS_ID && nexusId != NEW_VEGAS_NEXUS_ID) {
 			return false;
 		}
 
 		if (MOBase::QuestionBoxMemory::query(QApplication::activeModalWidget(), "BSAPacker", "Create .override file?",
-			"Do you want to create an override file for the archive?",
+			"Do you want to create an override file for the archive(s)?",
 			QDialogButtonBox::No | QDialogButtonBox::Yes, QDialogButtonBox::No) & QDialogButtonBox::No) {
 			return false;
 		}
 
-		const QString& fileNameNoExtension = modPath + '/' + archiveNameBase;
-		const std::string& absoluteFileName = fileNameNoExtension.toStdString() + ".override";
-		return this->m_FileWriterService->Write(absoluteFileName, nullptr, 0);
+		bool res = true;
+		for (const QString& baseName : archiveNames) {
+			const QString& fileNameNoExtension = modPath + '/' + baseName;
+			const std::string& absoluteFileName = fileNameNoExtension.toStdString() + ".override";
+			if (!this->m_FileWriterService->Write(absoluteFileName, nullptr, 0)) {
+				qWarning() << "Failed to create" << absoluteFileName;
+				res = false;
+			}
+		}
+		
+		return res;
 	}
 } // namespace BsaPacker

--- a/src/OverrideFileService.h
+++ b/src/OverrideFileService.h
@@ -11,7 +11,7 @@ namespace BsaPacker {
 		OverrideFileService(const IFileWriterService* fileWriterService);
 		bool CreateOverrideFile(const int nexusId,
 			const QString& modPath,
-			const QString& archiveNameBase) const override;
+			const QStringList& archiveNames) const override;
 
 	private:
 		const IFileWriterService* m_FileWriterService = nullptr;

--- a/src/TextureArchiveBuilder.cpp
+++ b/src/TextureArchiveBuilder.cpp
@@ -10,11 +10,15 @@ using namespace libbsarch;
 
 namespace BsaPacker
 {
+	// 4 GiB limit for the Fallout 4 Creation Kit. The game itself has no limit
+	// This does not consider size after compression or share data
+	const qint64 TextureArchiveBuilder::SIZE_LIMIT = (qint64)1024 * 1024 * 1024 * 4;
+
 	TextureArchiveBuilder::TextureArchiveBuilder(const IArchiveBuilderHelper* archiveBuilderHelper, const QDir& rootDir, const bsa_archive_type_t& type)
-		: m_ArchiveBuilderHelper(archiveBuilderHelper), m_RootDirectory(rootDir)
+		: m_ArchiveBuilderHelper(archiveBuilderHelper), m_RootDirectory(rootDir), m_ArchiveType(type)
 	{
 		this->m_Cancelled = false;
-		this->m_Archive = std::make_unique<libbsarch::bs_archive_auto>(type);
+		this->m_Archives.emplace_back(std::make_unique<libbsarch::bs_archive_auto>(this->m_ArchiveType));
 	}
 
 	uint32_t TextureArchiveBuilder::setFiles()
@@ -22,6 +26,7 @@ namespace BsaPacker
 		uint32_t incompressibleFiles = 0;
 		uint32_t compressibleFiles = 0;
 		int count = 0;
+		qint64 currentSize = 0;
 		const auto& dirString = (this->m_RootDirectory.path() + '/').toStdWString();
 		const auto& rootDirFiles = this->m_ArchiveBuilderHelper->getRootDirectoryFilenames(dirString);
 		qDebug() << "root is: " << m_RootDirectory.path() + '/';
@@ -31,11 +36,14 @@ namespace BsaPacker
 			QApplication::processEvents();
 
 			if (this->m_Cancelled) {
-				this->m_Archive.reset();
+				for (auto& archive : this->m_Archives) {
+					archive.reset();
+				}
 				return 0;
 			}
 
-			const QString& filepath = iterator.next();
+			const QFileInfo& fileInfo = iterator.nextFileInfo();
+			const QString& filepath = fileInfo.absoluteFilePath();
 			const bool ignored = this->m_ArchiveBuilderHelper->isFileIgnorable(filepath.toStdWString(), rootDirFiles);
 
 			Q_EMIT this->valueChanged(++count);
@@ -43,26 +51,37 @@ namespace BsaPacker
 				continue;
 			}
 
+			currentSize += fileInfo.size();
+			if (currentSize > SIZE_LIMIT) {
+				currentSize = fileInfo.size();
+				this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
+				this->m_Archives.back()->set_dds_callback(TextureArchiveBuilder::DDSCallback, this->getRootPath().toStdWString());
+				incompressibleFiles = 0;
+				compressibleFiles = 0;
+				this->m_Archives.emplace_back(std::make_unique<libbsarch::bs_archive_auto>(this->m_ArchiveType));
+				this->setShareData(true);
+			}
+
 			this->m_ArchiveBuilderHelper->isIncompressible(filepath.toStdWString()) ? ++incompressibleFiles : ++compressibleFiles;
 			auto fileBlob = disk_blob(
 				 dirString,
 				 filepath.toStdWString());
-			this->m_Archive->add_file_from_disk(fileBlob);
+			this->m_Archives.back()->add_file_from_disk(fileBlob);
 			qDebug() << "file is: " << filepath;
 		}
-		this->m_Archive->set_compressed(!static_cast<bool>(incompressibleFiles));
-		this->m_Archive->set_dds_callback(TextureArchiveBuilder::DDSCallback, this->getRootPath().toStdWString());
+		this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
+		this->m_Archives.back()->set_dds_callback(TextureArchiveBuilder::DDSCallback, this->getRootPath().toStdWString());
 		return incompressibleFiles + compressibleFiles;
 	}
 
 	void TextureArchiveBuilder::setShareData(const bool value)
 	{
-		this->m_Archive->set_share_data(value);
+		this->m_Archives.back()->set_share_data(value);
 	}
 
-	std::unique_ptr<libbsarch::bs_archive_auto> TextureArchiveBuilder::getArchive()
+	std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> TextureArchiveBuilder::getArchives()
 	{
-		return std::move(this->m_Archive);
+		return std::move(this->m_Archives);
 	}
 
 	uint32_t TextureArchiveBuilder::getFileCount() const

--- a/src/TextureArchiveBuilder.cpp
+++ b/src/TextureArchiveBuilder.cpp
@@ -10,7 +10,7 @@ using namespace libbsarch;
 
 namespace BsaPacker
 {
-	// 4 GiB limit for the Fallout 4 Creation Kit. The game itself has no limit
+	// 4 GiB limit for the Fallout 4 Creation Kit. The game itself has no limit so could make an optional setting
 	// This does not consider size after compression or share data
 	const qint64 TextureArchiveBuilder::SIZE_LIMIT = (qint64)1024 * 1024 * 1024 * 4;
 

--- a/src/TexturelessArchiveBuilder.cpp
+++ b/src/TexturelessArchiveBuilder.cpp
@@ -9,11 +9,15 @@ using namespace libbsarch;
 
 namespace BsaPacker
 {
+	// 4 GiB limit for the Fallout 4 Creation Kit. The game itself has no limit
+	// This does not consider size after compression or share data
+	const qint64 TexturelessArchiveBuilder::SIZE_LIMIT = (qint64)1024 * 1024 * 1024 * 4;
+
 	TexturelessArchiveBuilder::TexturelessArchiveBuilder(const IArchiveBuilderHelper* archiveBuilderHelper, const QDir& rootDir, const bsa_archive_type_t& type)
-		: m_ArchiveBuilderHelper(archiveBuilderHelper), m_RootDirectory(rootDir)
+		: m_ArchiveBuilderHelper(archiveBuilderHelper), m_RootDirectory(rootDir), m_ArchiveType(type)
 	{
 		this->m_Cancelled = false;
-		this->m_Archive = std::make_unique<libbsarch::bs_archive_auto>(type);
+		this->m_Archives.emplace_back(std::make_unique<libbsarch::bs_archive_auto>(this->m_ArchiveType));
 	}
 
 	uint32_t TexturelessArchiveBuilder::setFiles()
@@ -21,6 +25,7 @@ namespace BsaPacker
 		uint32_t incompressibleFiles = 0;
 		uint32_t compressibleFiles = 0;
 		int count = 0;
+		qint64 currentSize = 0;
 		const auto& dirString = (this->m_RootDirectory.path() + '/').toStdWString();
 		const auto& rootDirFiles = this->m_ArchiveBuilderHelper->getRootDirectoryFilenames(dirString);
 		qDebug() << "root is: " << m_RootDirectory.path() + '/';
@@ -30,11 +35,14 @@ namespace BsaPacker
 			QApplication::processEvents();
 
 			if (this->m_Cancelled) {
-				this->m_Archive.reset();
+				for (auto& archive : this->m_Archives) {
+					archive.reset();
+				}
 				return 0;
 			}
 
-			const QString& filepath = iterator.next();
+			const QFileInfo& fileInfo = iterator.nextFileInfo();
+			const QString& filepath = fileInfo.absoluteFilePath();
 			const bool ignored = this->m_ArchiveBuilderHelper->isFileIgnorable(filepath.toStdWString(), rootDirFiles);
 
 			Q_EMIT this->valueChanged(++count);
@@ -42,25 +50,35 @@ namespace BsaPacker
 				continue;
 			}
 
+			currentSize += fileInfo.size();
+			if (currentSize > SIZE_LIMIT) {
+				currentSize = fileInfo.size();
+				this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
+				incompressibleFiles = 0;
+				compressibleFiles = 0;
+				this->m_Archives.emplace_back(std::make_unique<libbsarch::bs_archive_auto>(this->m_ArchiveType));
+				this->setShareData(true);
+			}
+
 			this->m_ArchiveBuilderHelper->isIncompressible(filepath.toStdWString()) ? ++incompressibleFiles : ++compressibleFiles;
 			auto fileBlob = disk_blob(
 				 dirString,
 				 filepath.toStdWString());
-			this->m_Archive->add_file_from_disk(fileBlob);
+			this->m_Archives.back()->add_file_from_disk(fileBlob);
 			qDebug() << "file is: " << filepath;
 		}
-		this->m_Archive->set_compressed(!static_cast<bool>(incompressibleFiles));
+		this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
 		return incompressibleFiles + compressibleFiles;
 	}
 
 	void TexturelessArchiveBuilder::setShareData(const bool value)
 	{
-		this->m_Archive->set_share_data(value);
+		this->m_Archives.back()->set_share_data(value);
 	}
 
-	std::unique_ptr<libbsarch::bs_archive_auto> TexturelessArchiveBuilder::getArchive()
+	std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> TexturelessArchiveBuilder::getArchives()
 	{
-		return std::move(this->m_Archive);
+		return std::move(this->m_Archives);
 	}
 
 	uint32_t TexturelessArchiveBuilder::getFileCount() const

--- a/src/TexturelessArchiveBuilder.cpp
+++ b/src/TexturelessArchiveBuilder.cpp
@@ -9,7 +9,7 @@ using namespace libbsarch;
 
 namespace BsaPacker
 {
-	// 4 GiB limit for the Fallout 4 Creation Kit. The game itself has no limit
+	// 4 GiB limit for the Fallout 4 Creation Kit. The game itself has no limit so could make an optional setting
 	// This does not consider size after compression or share data
 	const qint64 TexturelessArchiveBuilder::SIZE_LIMIT = (qint64)1024 * 1024 * 1024 * 4;
 

--- a/src/bsapacker/GeneralArchiveBuilder.h
+++ b/src/bsapacker/GeneralArchiveBuilder.h
@@ -17,7 +17,7 @@ namespace BsaPacker
 		GeneralArchiveBuilder(const IArchiveBuilderHelper* archiveBuilderHelper, const QDir& rootDir, const bsa_archive_type_t& type);
 		uint32_t setFiles() override;
 		void setShareData(bool value) override;
-		[[nodiscard]] std::unique_ptr<libbsarch::bs_archive_auto> getArchive() override;
+		[[nodiscard]] std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> getArchives() override;
 		[[nodiscard]] uint32_t getFileCount() const override;
 		[[nodiscard]] QString getRootPath() const override;
 
@@ -26,9 +26,11 @@ namespace BsaPacker
 
 	private:
 		const IArchiveBuilderHelper* m_ArchiveBuilderHelper = nullptr;
-		std::unique_ptr<libbsarch::bs_archive_auto> m_Archive;
+		std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> m_Archives;
+		const bsa_archive_type_t m_ArchiveType;
 		bool m_Cancelled;
 		QDir m_RootDirectory;
+		const static qint64 SIZE_LIMIT;
 	};
 } // namespace BsaPacker
 

--- a/src/bsapacker/IArchiveBuilder.h
+++ b/src/bsapacker/IArchiveBuilder.h
@@ -15,7 +15,7 @@ namespace BsaPacker
 		virtual ~IArchiveBuilder() = default;
 		virtual uint32_t setFiles() = 0;
 		virtual void setShareData(bool) = 0;
-		[[nodiscard]] virtual std::unique_ptr<libbsarch::bs_archive_auto> getArchive() = 0;
+		[[nodiscard]] virtual std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> getArchives() = 0;
 		[[nodiscard]] virtual uint32_t getFileCount() const = 0;
 		[[nodiscard]] virtual QString getRootPath() const = 0;
 	};

--- a/src/bsapacker/IArchiveNameService.h
+++ b/src/bsapacker/IArchiveNameService.h
@@ -14,6 +14,7 @@ namespace BsaPacker
 		virtual QString GetFileExtension() const = 0;
 		virtual QString GetArchiveFullPath(bsa_archive_type_e, const IModDto*) const = 0;
 		virtual QString Infix(bsa_archive_type_e type) const = 0;
+		virtual QString Suffix(const QString& pathNoExt) const = 0;
 	};
 }
 

--- a/src/bsapacker/IOverrideFileService.h
+++ b/src/bsapacker/IOverrideFileService.h
@@ -1,7 +1,7 @@
 #ifndef IOVERRIDEFILESERVICE_H
 #define IOVERRIDEFILESERVICE_H
 
-#include <QString>
+#include <QStringList>
 
 namespace BsaPacker {
 	class IOverrideFileService {
@@ -9,7 +9,7 @@ namespace BsaPacker {
 		virtual ~IOverrideFileService() = default;
 		virtual bool CreateOverrideFile(const int nexusId,
 			const QString& modPath,
-			const QString& archiveNameBase) const = 0;
+			const QStringList& archiveNames) const = 0;
 	};
 } // namespace BsaPacker
 

--- a/src/bsapacker/NullArchiveBuilder.h
+++ b/src/bsapacker/NullArchiveBuilder.h
@@ -16,7 +16,7 @@ namespace BsaPacker
 
 		uint32_t setFiles() override;
 		void setShareData(bool) override;
-		[[nodiscard]] std::unique_ptr<libbsarch::bs_archive_auto> getArchive() override;
+		[[nodiscard]] std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> getArchives() override;
 		[[nodiscard]] uint32_t getFileCount() const override;
 		[[nodiscard]] QString getRootPath() const override;
 

--- a/src/bsapacker/TextureArchiveBuilder.h
+++ b/src/bsapacker/TextureArchiveBuilder.h
@@ -19,7 +19,7 @@ namespace BsaPacker
 
 		uint32_t setFiles() override;
 		void setShareData(bool) override;
-		[[nodiscard]] std::unique_ptr<libbsarch::bs_archive_auto> getArchive() override;
+		[[nodiscard]] std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> getArchives() override;
 		[[nodiscard]] uint32_t getFileCount() const override;
 		[[nodiscard]] QString getRootPath() const override;
 
@@ -28,9 +28,11 @@ namespace BsaPacker
 
 	private:
 		const IArchiveBuilderHelper* m_ArchiveBuilderHelper = nullptr;
-		std::unique_ptr<libbsarch::bs_archive_auto> m_Archive;
+		std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> m_Archives;
+		const bsa_archive_type_t m_ArchiveType;
 		bool m_Cancelled;
 		QDir m_RootDirectory;
+		const static qint64 SIZE_LIMIT;
 
 		static void DDSCallback(bsa_archive_t archive, const wchar_t* file_path, bsa_dds_info_t* dds_info, void* context);
 	};

--- a/src/bsapacker/TexturelessArchiveBuilder.h
+++ b/src/bsapacker/TexturelessArchiveBuilder.h
@@ -19,7 +19,7 @@ namespace BsaPacker
 
 		uint32_t setFiles() override;
 		void setShareData(bool) override;
-		[[nodiscard]] std::unique_ptr<libbsarch::bs_archive_auto> getArchive() override;
+		[[nodiscard]] std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> getArchives() override;
 		[[nodiscard]] uint32_t getFileCount() const override;
 		[[nodiscard]] QString getRootPath() const override;
 
@@ -28,9 +28,11 @@ namespace BsaPacker
 
 	private:
 		const IArchiveBuilderHelper* m_ArchiveBuilderHelper = nullptr;
-		std::unique_ptr<libbsarch::bs_archive_auto> m_Archive;
+		std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> m_Archives;
+		const bsa_archive_type_t m_ArchiveType;
 		bool m_Cancelled;
 		QDir m_RootDirectory;
+		const static qint64 SIZE_LIMIT;
 	};
 } // namespace BsaPacker
 


### PR DESCRIPTION
This creates a new archive container when 2GiB is reached for BSAs and 4GiB for BA2s. For BSAs, it prevents creating an unusable archive for mods that have many GiB of textures such as Fallout - The Frontier. There is also a small change to prevent showing separators as mods that can be packed in the dialog.

There is an existing (unimplemented) SETTING_SPLIT_ARCHIVES that I may repurpose to make splitting BA2s optional later on.