### PR TITLE
Always compress baFO4dds and baSFdds archives and use completeBaseName for created archives.

### DIFF
--- a/src/BsaPackerWorker.cpp
+++ b/src/BsaPackerWorker.cpp
@@ -42,7 +42,7 @@ namespace BsaPacker
 					const QFileInfo fileInfo(this->m_ArchiveNameService->GetArchiveFullPath(type, modDto.get()));
 					bool res = this->m_ArchiveAutoService->CreateBSA(archive.get(), fileInfo.absoluteFilePath(), type);
 					if (res) {
-						createdArchives.append(fileInfo.baseName());
+						createdArchives.append(fileInfo.completeBaseName());
 					}
 				}
 			}

--- a/src/SettingsService.cpp
+++ b/src/SettingsService.cpp
@@ -11,8 +11,8 @@ namespace BsaPacker
 	const QList<MOBase::PluginSetting>& SettingsService::PluginSettings = {
 		MOBase::PluginSetting(SettingsService::SETTING_HIDE_LOOSE_ASSETS, QObject::tr("After creating the archive, set loose assets to hidden."), false),
 		MOBase::PluginSetting(SettingsService::SETTING_CREATE_PLUGINS, QObject::tr("Create a dummy plugin to load the archive if one does not exist."), false),
-		MOBase::PluginSetting(SettingsService::SETTING_BLACKLISTED_FILES, QObject::tr("Specify a semi-colon seperated list of file extensions to ignore when packing."), ".txt;.hkx;.xml;.ini;.bk2"),
-		MOBase::PluginSetting(SettingsService::SETTING_COMPRESS_ARCHIVES, QObject::tr("Compress archives if they do not contain incompressible files."), true)
+		MOBase::PluginSetting(SettingsService::SETTING_BLACKLISTED_FILES, QObject::tr("Specify a semi-colon separated list of file extensions to ignore when packing."), ".txt;.hkx;.xml;.ini;.bk2"),
+		MOBase::PluginSetting(SettingsService::SETTING_COMPRESS_ARCHIVES, QObject::tr("Compress archives if they do not contain incompressible files. Texture archives for Fallout 4 and Starfield will always be compressed. Morrowind archives will never be compressed."), true)
 		//MOBase::PluginSetting(SettingsService::SETTING_SPLIT_ARCHIVES, QObject::tr("Automatically create multiple archives if they exceed the size limit."), false);
 	};
 

--- a/src/TextureArchiveBuilder.cpp
+++ b/src/TextureArchiveBuilder.cpp
@@ -23,7 +23,6 @@ namespace BsaPacker
 
 	uint32_t TextureArchiveBuilder::setFiles()
 	{
-		uint32_t incompressibleFiles = 0;
 		uint32_t compressibleFiles = 0;
 		int count = 0;
 		qint64 currentSize = 0;
@@ -54,24 +53,23 @@ namespace BsaPacker
 			currentSize += fileInfo.size();
 			if (currentSize > SIZE_LIMIT) {
 				currentSize = fileInfo.size();
-				this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
+				this->m_Archives.back()->set_compressed(true);
 				this->m_Archives.back()->set_dds_callback(TextureArchiveBuilder::DDSCallback, this->getRootPath().toStdWString());
-				incompressibleFiles = 0;
 				compressibleFiles = 0;
 				this->m_Archives.emplace_back(std::make_unique<libbsarch::bs_archive_auto>(this->m_ArchiveType));
 				this->setShareData(true);
 			}
 
-			this->m_ArchiveBuilderHelper->isIncompressible(filepath.toStdWString()) ? ++incompressibleFiles : ++compressibleFiles;
+			++compressibleFiles;
 			auto fileBlob = disk_blob(
 				 dirString,
 				 filepath.toStdWString());
 			this->m_Archives.back()->add_file_from_disk(fileBlob);
 			qDebug() << "file is: " << filepath;
 		}
-		this->m_Archives.back()->set_compressed(!static_cast<bool>(incompressibleFiles));
+		this->m_Archives.back()->set_compressed(true);
 		this->m_Archives.back()->set_dds_callback(TextureArchiveBuilder::DDSCallback, this->getRootPath().toStdWString());
-		return incompressibleFiles + compressibleFiles;
+		return compressibleFiles;
 	}
 
 	void TextureArchiveBuilder::setShareData(const bool value)


### PR DESCRIPTION
Texture type archives for Fallout 4 and Starfield must always be compressed or the game will crash or load infinitely. Morrowind archives must not be compressed. This is information from the BSArchPro tool. I am not sure if having a dedicated MorrowindArchiveBuilder is the best way forward, but it was simple.