### PR TITLE
Delegate archive creation to GameArchiveHandler for non-Bethesda games

### DIFF
--- a/src/BsaPacker.cpp
+++ b/src/BsaPacker.cpp
@@ -18,9 +18,28 @@
 #include <bsapacker/ModDtoFactory.h>
 #include <QMessageBox>
 #include <iplugingame.h>
+#include <uibase/game_features/dataarchives.h>
+#include <uibase/game_features/gamearchivehandler.h>
+#include <uibase/game_features/igamefeatures.h>
 
 #include <boost/di.hpp>
 namespace di = boost::di;
+
+namespace
+{
+	bool supportsArchivePacking(MOBase::IOrganizer* organizer)
+	{
+		if (organizer == nullptr || organizer->gameFeatures() == nullptr) {
+			return false;
+		}
+
+		if (organizer->gameFeatures()->gameFeature<MOBase::DataArchives>() != nullptr) {
+			return true;
+		}
+
+		return organizer->gameFeatures()->gameFeature<MOBase::GameArchiveHandler>() != nullptr;
+	}
+}
 
 namespace BsaPacker
 {
@@ -35,6 +54,15 @@ namespace BsaPacker
 	QString Bsa_Packer::name() const
 	{
 		return QStringLiteral("BSA Packer");
+	}
+
+	std::vector<std::shared_ptr<const MOBase::IPluginRequirement>> Bsa_Packer::requirements() const
+	{
+		return {
+			Requirements::basic([](MOBase::IOrganizer* organizer) {
+				return supportsArchivePacking(organizer);
+			}, QStringLiteral("Requires a game with built-in archive support or a game-provided archive handler."))
+		};
 	}
 
 	QString Bsa_Packer::author() const
@@ -59,7 +87,7 @@ namespace BsaPacker
 
 	QString Bsa_Packer::tooltip() const
 	{
-		return tr("Transform loose files into a Bethesda Softworks Archive file (.bsa/.ba2).");
+		return tr("Transform loose files into a supported archive file for the current game.");
 	}
 
 	QIcon Bsa_Packer::icon() const
@@ -74,6 +102,12 @@ namespace BsaPacker
 
 	void Bsa_Packer::display() const
 	{
+		if (!supportsArchivePacking(this->m_Organizer)) {
+			QMessageBox::information(nullptr, QStringLiteral("BSA Packer"),
+				tr("Archive packing is not supported for the current game."));
+			return;
+		}
+
 		const auto injector = di::make_injector(
 			di::bind<IModContext>.to(this->m_ModContext.get()),
 			di::bind<ISettingsService>.to(this->m_SettingsService.get()),

--- a/src/BsaPacker.h
+++ b/src/BsaPacker.h
@@ -17,15 +17,14 @@ namespace BsaPacker
 #endif
 
 	public:
-		// IPlugin interface
 		bool init(MOBase::IOrganizer* moInfo) override;
 		[[nodiscard]] QString name() const override;
+		[[nodiscard]] std::vector<std::shared_ptr<const MOBase::IPluginRequirement>> requirements() const override;
 		[[nodiscard]] QString author() const override;
 		[[nodiscard]] QString description() const override;
 		[[nodiscard]] MOBase::VersionInfo version() const override;
 		[[nodiscard]] QList<MOBase::PluginSetting> settings() const override;
 
-		// IPluginTool interface
 		[[nodiscard]] QString displayName() const override;
 		[[nodiscard]] QString tooltip() const override;
 		[[nodiscard]] QIcon icon() const override;

--- a/src/BsaPackerWorker.cpp
+++ b/src/BsaPackerWorker.cpp
@@ -1,5 +1,7 @@
 #include "BsaPackerWorker.h"
 
+#include <QDir>
+#include <QFileInfo>
 #include <QMessageBox>
 
 #include <bsapacker/ArchiveBuildDirector.h>
@@ -9,6 +11,7 @@ namespace BsaPacker
 {
 	BsaPackerWorker::BsaPackerWorker(
 		const ISettingsService* settingsService,
+		const IModContext* modContext,
 		const IModDtoFactory* modDtoFactory,
 		const IArchiveBuilderFactory* archiveBuilderFactory,
 		const IArchiveAutoService* archiveAutoService,
@@ -17,6 +20,7 @@ namespace BsaPacker
 		const IArchiveNameService* archiveNameService,
 		const IOverrideFileService* overrideFileService) :
 		m_SettingsService(settingsService),
+		m_ModContext(modContext),
 		m_ModDtoFactory(modDtoFactory),
 		m_ArchiveBuilderFactory(archiveBuilderFactory),
 		m_ArchiveAutoService(archiveAutoService),
@@ -30,34 +34,65 @@ namespace BsaPacker
 	void BsaPackerWorker::DoWork() const
 	{
 		QStringList createdArchives;
-		const std::unique_ptr<IModDto> modDto = this->m_ModDtoFactory->Create(); // handles PackerDialog and validation, implements Null Object pattern
-		const std::vector<bsa_archive_type_e> types = this->m_ArchiveBuilderFactory->GetArchiveTypes(modDto.get());
-		for (auto&& type : types) {
-			const std::unique_ptr<IArchiveBuilder> builder = this->m_ArchiveBuilderFactory->Create(type, modDto.get());
-			ArchiveBuildDirector director(this->m_SettingsService, builder.get());
-			director.Construct(); // must check if cancelled
-			const std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> archives = builder->getArchives();
-			for (const auto& archive : archives) {
-				if (archive) {
-					const QFileInfo fileInfo(this->m_ArchiveNameService->GetArchiveFullPath(type, modDto.get()));
-					bool res = this->m_ArchiveAutoService->CreateBSA(archive.get(), fileInfo.absoluteFilePath(), type);
-					if (res) {
-						createdArchives.append(fileInfo.completeBaseName());
+		QStringList createdArchiveFileNames;
+		const std::unique_ptr<IModDto> modDto = this->m_ModDtoFactory->Create();
+		if (modDto->Directory().isEmpty()) {
+			return;
+		}
+
+		const bool useBuiltInArchiveTools = this->m_ModContext != nullptr && this->m_ModContext->CanUseBuiltInArchiveTools();
+		const bool useArchiveHandler = this->m_ModContext != nullptr && !useBuiltInArchiveTools && this->m_ModContext->HasArchiveCreationHandler();
+		if (!useBuiltInArchiveTools && !useArchiveHandler) {
+			QMessageBox::warning(nullptr, QString(), QObject::tr("Archive packing is not supported for the current game."));
+			return;
+		}
+
+		if (useBuiltInArchiveTools) {
+			const std::vector<bsa_archive_type_e> types = this->m_ArchiveBuilderFactory->GetArchiveTypes(modDto.get());
+			for (auto&& type : types) {
+				const std::unique_ptr<IArchiveBuilder> builder = this->m_ArchiveBuilderFactory->Create(type, modDto.get());
+				ArchiveBuildDirector director(this->m_SettingsService, builder.get());
+				director.Construct();
+				const std::vector<std::unique_ptr<libbsarch::bs_archive_auto>> archives = builder->getArchives();
+				for (const auto& archive : archives) {
+					if (archive) {
+						const QFileInfo fileInfo(this->m_ArchiveNameService->GetArchiveFullPath(type, modDto.get()));
+						bool res = this->m_ArchiveAutoService->CreateBSA(archive.get(), fileInfo.absoluteFilePath(), type);
+						if (res) {
+							createdArchives.append(fileInfo.completeBaseName());
+							createdArchiveFileNames.append(fileInfo.fileName());
+						}
 					}
 				}
 			}
+		} else {
+			const QString archivePath = QDir(modDto->Directory()).filePath(modDto->ArchiveName() + modDto->ArchiveExtension());
+			QString errorMessage;
+			if (!this->m_ModContext->CreateArchive(modDto->Directory(), archivePath, &errorMessage)) {
+				QMessageBox::warning(nullptr, QString(),
+					errorMessage.isEmpty() ? QObject::tr("Failed to create archive.") : errorMessage);
+				return;
+			}
+
+			const QFileInfo fileInfo(archivePath);
+			createdArchives.append(fileInfo.completeBaseName());
+			createdArchiveFileNames.append(fileInfo.fileName());
 		}
 
-		if (!createdArchives.isEmpty()) {
-			QMessageBox::information(nullptr, "",
-        QObject::tr("Created archive(s):") + "\n" + createdArchives.join(modDto->ArchiveExtension() +",\n") + modDto->ArchiveExtension());
-			this->m_OverrideFileService->CreateOverrideFile(modDto->NexusId(), modDto->Directory(), createdArchives);
+		if (!createdArchiveFileNames.isEmpty()) {
+			QMessageBox::information(nullptr, QString(),
+				QObject::tr("Created archive(s):") + "\n" + createdArchiveFileNames.join(",\n"));
+			if (useBuiltInArchiveTools) {
+				this->m_OverrideFileService->CreateOverrideFile(modDto->NexusId(), modDto->Directory(), createdArchives);
+			}
 		}
 
-		const std::unique_ptr<IDummyPluginService> pluginService = this->m_DummyPluginServiceFactory->Create();
-		pluginService->CreatePlugin(modDto->Directory(), modDto->ArchiveName());
+		if (useBuiltInArchiveTools) {
+			const std::unique_ptr<IDummyPluginService> pluginService = this->m_DummyPluginServiceFactory->Create();
+			pluginService->CreatePlugin(modDto->Directory(), modDto->ArchiveName());
+		}
 
-		if (!modDto->Directory().isEmpty()) {
+		if (!createdArchiveFileNames.isEmpty() && !modDto->Directory().isEmpty()) {
 			this->m_HideLooseAssetService->HideLooseAssets(modDto->Directory());
 		}
 	}

--- a/src/BsaPackerWorker.cpp
+++ b/src/BsaPackerWorker.cpp
@@ -1,6 +1,7 @@
 #include "BsaPackerWorker.h"
 
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QMessageBox>
 
@@ -67,6 +68,13 @@ namespace BsaPacker
 			}
 		} else {
 			const QString archivePath = QDir(modDto->Directory()).filePath(modDto->ArchiveName() + modDto->ArchiveExtension());
+			const QFileInfo existingArchiveInfo(archivePath);
+			if (existingArchiveInfo.exists() && existingArchiveInfo.isFile() && !QFile::remove(archivePath)) {
+				QMessageBox::warning(nullptr, QString(),
+					QObject::tr("Failed to replace existing archive: %1").arg(existingArchiveInfo.fileName()));
+				return;
+			}
+
 			QString errorMessage;
 			if (!this->m_ModContext->CreateArchive(modDto->Directory(), archivePath, &errorMessage)) {
 				QMessageBox::warning(nullptr, QString(),
@@ -97,3 +105,5 @@ namespace BsaPacker
 		}
 	}
 }
+
+

--- a/src/BsaPackerWorker.cpp
+++ b/src/BsaPackerWorker.cpp
@@ -105,5 +105,3 @@ namespace BsaPacker
 		}
 	}
 }
-
-

--- a/src/BsaPackerWorker.h
+++ b/src/BsaPackerWorker.h
@@ -3,6 +3,7 @@
 
 #include "bsapacker_global.h"
 #include <bsapacker/ISettingsService.h>
+#include <bsapacker/IModContext.h>
 #include <bsapacker/IModDtoFactory.h>
 #include <bsapacker/IArchiveBuilderFactory.h>
 #include <bsapacker/IArchiveAutoService.h>
@@ -18,6 +19,7 @@ namespace BsaPacker
 	public:
 		BsaPackerWorker(
 			const ISettingsService* settingsService,
+			const IModContext* modContext,
 			const IModDtoFactory* modDtoFactory,
 			const IArchiveBuilderFactory* archiveBuilderFactory,
 			const IArchiveAutoService* archiveAutoService,
@@ -29,6 +31,7 @@ namespace BsaPacker
 
 	private:
 		const ISettingsService* m_SettingsService = nullptr;
+		const IModContext* m_ModContext = nullptr;
 		const IModDtoFactory* m_ModDtoFactory = nullptr;
 		const IArchiveBuilderFactory* m_ArchiveBuilderFactory = nullptr;
 		const IArchiveAutoService* m_ArchiveAutoService = nullptr;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,4 +23,3 @@ install(FILES $<TARGET_FILE:Qt6::Concurrent> DESTINATION bin/dlls)
 # install(FILES $<TARGET_FILE:mo2::libbsarch> DESTINATION bin/dlls)
 
 mo2_install_plugin(bsa_packer)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,3 +23,4 @@ install(FILES $<TARGET_FILE:Qt6::Concurrent> DESTINATION bin/dlls)
 # install(FILES $<TARGET_FILE:mo2::libbsarch> DESTINATION bin/dlls)
 
 mo2_install_plugin(bsa_packer)
+

--- a/src/ModContext.cpp
+++ b/src/ModContext.cpp
@@ -2,10 +2,14 @@
 
 #include <array>
 #include <functional>
-#include "iplugingame.h"
-#include "imodinterface.h"
-#include "imodlist.h"
+
 #include "NexusId.h"
+#include <imodinterface.h>
+#include <imodlist.h>
+#include <iplugingame.h>
+#include <uibase/game_features/dataarchives.h>
+#include <uibase/game_features/gamearchivehandler.h>
+#include <uibase/game_features/igamefeatures.h>
 #include <QtConcurrent/QtConcurrentFilter>
 #include <QtConcurrent/QtConcurrentMap>
 
@@ -13,11 +17,11 @@ namespace BsaPacker
 {
 	const QStringList& ModContext::PLUGIN_TYPES = { "*.esm", "*.esp", "*.esl" };
 
-	ModContext::ModContext(MOBase::IOrganizer *moInfo) : m_Organizer(moInfo)
+	ModContext::ModContext(MOBase::IOrganizer* moInfo) : m_Organizer(moInfo)
 	{
 	}
 
-	QString ModContext::GetAbsoluteModPath(const QString &modName) const
+	QString ModContext::GetAbsoluteModPath(const QString& modName) const
 	{
 		const MOBase::IModInterface* const mod = m_Organizer->modList()->getMod(modName);
 		return mod->absolutePath();
@@ -28,13 +32,12 @@ namespace BsaPacker
 		const MOBase::IPluginGame* managedGame = this->m_Organizer->managedGame();
 		int nexusId = managedGame->nexusGameID();
 
-		// Games with no Nexus page have an ID of 0. Use primarySources in that case
 		if (nexusId != 0) {
 			return nexusId;
 		}
 		if (!managedGame->primarySources().isEmpty()) {
 			QString primarySource = managedGame->primarySources().first();
-			if (primarySource == "FalloutNV") { // TTW
+			if (primarySource == "FalloutNV") {
 				return NexusId::NewVegas;
 			}
 		}
@@ -43,6 +46,12 @@ namespace BsaPacker
 
 	QStringList ModContext::GetPlugins(const QDir& modDirectory) const
 	{
+		if (!CanUseBuiltInArchiveTools()) {
+			return HasArchiveCreationHandler()
+				? QStringList{ QStringLiteral("<new archive filename>") }
+				: QStringList{};
+		}
+
 		const int nexusId = this->GetNexusId();
 		const QString extension = (nexusId == NexusId::Fallout4 || nexusId == NexusId::Starfield) ? ".ba2" : ".bsa";
 		const std::function<QString(QString)> replace_extension = [&](QString fname) {
@@ -62,5 +71,39 @@ namespace BsaPacker
 			return !mod.endsWith("_separator", Qt::CaseInsensitive) && (list->state(mod) & MOBase::IModList::STATE_VALID);
 		};
 		return QtConcurrent::blockingFiltered(list->allMods(), modStateValid);
+	}
+
+	bool ModContext::CanUseBuiltInArchiveTools() const
+	{
+		return m_Organizer != nullptr && m_Organizer->gameFeatures() != nullptr &&
+			m_Organizer->gameFeatures()->gameFeature<MOBase::DataArchives>() != nullptr;
+	}
+
+	bool ModContext::HasArchiveCreationHandler() const
+	{
+		return ArchiveHandler() != nullptr;
+	}
+
+	bool ModContext::CanCreateArchive(const QString& archivePath) const
+	{
+		auto handler = ArchiveHandler();
+		return handler != nullptr && handler->canCreateArchive(archivePath);
+	}
+
+	bool ModContext::CreateArchive(const QString& sourceDirectory,
+		const QString& archivePath,
+		QString* errorMessage) const
+	{
+		auto handler = ArchiveHandler();
+		return handler != nullptr && handler->createArchive(sourceDirectory, archivePath, {}, errorMessage);
+	}
+
+	std::shared_ptr<const MOBase::GameArchiveHandler> ModContext::ArchiveHandler() const
+	{
+		if (m_Organizer == nullptr || m_Organizer->gameFeatures() == nullptr) {
+			return {};
+		}
+
+		return m_Organizer->gameFeatures()->gameFeature<MOBase::GameArchiveHandler>();
 	}
 } // namespace BsaPacker

--- a/src/ModContext.h
+++ b/src/ModContext.h
@@ -5,6 +5,13 @@
 #include <bsapacker/IModContext.h>
 #include <imoinfo.h>
 
+#include <memory>
+
+namespace MOBase
+{
+class GameArchiveHandler;
+}
+
 namespace BsaPacker
 {
 	class BSAPACKER_EXPORT ModContext : public IModContext
@@ -15,6 +22,15 @@ namespace BsaPacker
 		[[nodiscard]] int GetNexusId() const override;
 		[[nodiscard]] QStringList GetPlugins(const QDir& modDirectory) const override;
 		[[nodiscard]] QStringList GetValidMods() const override;
+		[[nodiscard]] bool CanUseBuiltInArchiveTools() const override;
+		[[nodiscard]] bool HasArchiveCreationHandler() const override;
+		[[nodiscard]] bool CanCreateArchive(const QString& archivePath) const override;
+		[[nodiscard]] bool CreateArchive(const QString& sourceDirectory,
+			const QString& archivePath,
+			QString* errorMessage = nullptr) const override;
+
+	private:
+		[[nodiscard]] std::shared_ptr<const MOBase::GameArchiveHandler> ArchiveHandler() const;
 
 	private:
 		const MOBase::IOrganizer* m_Organizer = nullptr;

--- a/src/ModDtoFactory.cpp
+++ b/src/ModDtoFactory.cpp
@@ -3,6 +3,7 @@
 #include "ModDto.h"
 #include "NullModDto.h"
 #include "PackerDialog.h"
+#include <QFileInfo>
 #include <QInputDialog>
 #include <QMessageBox>
 
@@ -28,19 +29,46 @@ namespace BsaPacker
 			return std::make_unique<NullModDto>();
 		}
 
+		const bool useBuiltInArchiveTools = this->m_ModContext->CanUseBuiltInArchiveTools();
+		const bool useArchiveHandler = !useBuiltInArchiveTools && this->m_ModContext->HasArchiveCreationHandler();
+		if (!useBuiltInArchiveTools && !useArchiveHandler) {
+			QMessageBox::warning(nullptr, QStringLiteral("BSA Packer"),
+				QObject::tr("Archive packing is not supported for the current game."));
+			return std::make_unique<NullModDto>();
+		}
+
 		const int nexusId = this->m_ModContext->GetNexusId();
 		const QString& modName = this->m_PackerDialog->SelectedMod();
 		const QString& modDir = this->m_ModContext->GetAbsoluteModPath(modName);
 		const QString& pluginName = this->m_PackerDialog->SelectedPluginItem();
 		const bool needsNewName = this->m_PackerDialog->IsNewFilename();
-		const QString& archiveName = ModDtoFactory::ArchiveNameValidator(modName, pluginName, needsNewName);
-		if (archiveName == nullptr) {
+		const QString archiveName = ModDtoFactory::ArchiveNameValidator(modName, pluginName, needsNewName, useArchiveHandler);
+		if (archiveName.isNull()) {
 			return std::make_unique<NullModDto>();
 		}
 
-		const QString& archiveExtension = (nexusId == FALLOUT_4_NEXUS_ID || nexusId == STARFIELD_NEXUS_ID)
-				? QStringLiteral(".ba2")
-				: QStringLiteral(".bsa");
+		if (useArchiveHandler) {
+			const QFileInfo archiveInfo(archiveName);
+			const QString completeSuffix = archiveInfo.completeSuffix();
+			if (completeSuffix.isEmpty()) {
+				QMessageBox::warning(nullptr, QStringLiteral("BSA Packer"),
+					QObject::tr("Archive filename must include an extension."));
+				return std::make_unique<NullModDto>();
+			}
+
+			const QString archivePath = QDir(modDir).filePath(archiveInfo.fileName());
+			if (!this->m_ModContext->CanCreateArchive(archivePath)) {
+				QMessageBox::warning(nullptr, QStringLiteral("BSA Packer"),
+					QObject::tr("Archive packing is not supported for \"%1\".").arg(archiveInfo.fileName()));
+				return std::make_unique<NullModDto>();
+			}
+
+			return std::make_unique<ModDto>(nexusId, modDir, archiveInfo.completeBaseName(), QStringLiteral(".") + completeSuffix);
+		}
+
+		const QString archiveExtension = (nexusId == FALLOUT_4_NEXUS_ID || nexusId == STARFIELD_NEXUS_ID)
+			? QStringLiteral(".ba2")
+			: QStringLiteral(".bsa");
 
 		return std::make_unique<ModDto>(nexusId, modDir, archiveName, archiveExtension);
 	}
@@ -48,35 +76,38 @@ namespace BsaPacker
 	QString ModDtoFactory::ArchiveNameValidator(
 		const QString& modName,
 		const QString& pluginName,
-		const bool needsNewName)
+		const bool needsNewName,
+		const bool requiresFullFilename)
 	{
 		QString archive_name_base;
 		if (needsNewName) {
 			bool ok = false;
-			const QString& name = QInputDialog::getText(nullptr,
-														QStringLiteral("BSA Packer"),
-														QObject::tr("Archive name (no file extension):"),
-														QLineEdit::Normal,
-														modName,
-														&ok).simplified();
+			const QString title = QStringLiteral("BSA Packer");
+			const QString prompt = requiresFullFilename
+				? QObject::tr("Archive filename:")
+				: QObject::tr("Archive name (no file extension):");
+			const QString name = QInputDialog::getText(nullptr,
+				title,
+				prompt,
+				QLineEdit::Normal,
+				modName,
+				&ok).simplified();
 			if (!ok) {
-				return nullptr;
+				return QString();
 			}
-			// Nameless plugins are not loaded in the games I tested. Nameless archives can be loaded in
-			// some games using the SArchiveList INI setting or equivalent. It is simpler to just prevent nameless archives
 			else if (name.isEmpty()) {
 				qWarning("Archive name cannot be empty. Cancelling archive creation.");
-				return nullptr;
+				return QString();
 			}
 			archive_name_base = name;
 		} else {
-			archive_name_base = pluginName.chopped(4); // trims the file extension off
+			archive_name_base = requiresFullFilename ? pluginName : pluginName.chopped(4);
 		}
 		return archive_name_base;
 	}
 
 	bool ModDtoFactory::CanOverwriteFile(const QString& filePath,
-										 const QString& fileName)
+		const QString& fileName)
 	{
 		const QString& absoluteFileName = filePath + '/' + fileName;
 		const QFileInfo fileInfo(absoluteFileName);

--- a/src/bsapacker/IModContext.h
+++ b/src/bsapacker/IModContext.h
@@ -14,6 +14,12 @@ namespace BsaPacker
 		[[nodiscard]] virtual int GetNexusId() const = 0;
 		[[nodiscard]] virtual QStringList GetPlugins(const QDir& modDirectory) const = 0;
 		[[nodiscard]] virtual QStringList GetValidMods() const = 0;
+		[[nodiscard]] virtual bool CanUseBuiltInArchiveTools() const = 0;
+		[[nodiscard]] virtual bool HasArchiveCreationHandler() const = 0;
+		[[nodiscard]] virtual bool CanCreateArchive(const QString& archivePath) const = 0;
+		[[nodiscard]] virtual bool CreateArchive(const QString& sourceDirectory,
+			const QString& archivePath,
+			QString* errorMessage = nullptr) const = 0;
 	};
 } // namespace BsaPacker
 

--- a/src/bsapacker/ModDtoFactory.h
+++ b/src/bsapacker/ModDtoFactory.h
@@ -20,7 +20,8 @@ namespace BsaPacker
 		[[nodiscard]] static QString ArchiveNameValidator(
 			const QString& modName,
 			const QString& pluginName,
-			const bool needsNewName);
+			const bool needsNewName,
+			const bool requiresFullFilename);
 		[[nodiscard]] static bool CanOverwriteFile(
 			const QString& filePath,
 			const QString& fileName);

--- a/tests/MockModContext.h
+++ b/tests/MockModContext.h
@@ -10,4 +10,8 @@ public:
 	MOCK_METHOD(int, GetNexusId, (), (const, override));
 	MOCK_METHOD(QStringList, GetPlugins, (const QDir& modDirectory), (const, override));
 	MOCK_METHOD(QStringList, GetValidMods, (), (const, override));
+	MOCK_METHOD(bool, CanUseBuiltInArchiveTools, (), (const, override));
+	MOCK_METHOD(bool, HasArchiveCreationHandler, (), (const, override));
+	MOCK_METHOD(bool, CanCreateArchive, (const QString& archivePath), (const, override));
+	MOCK_METHOD(bool, CreateArchive, (const QString& sourceDirectory, const QString& archivePath, QString* errorMessage), (const, override));
 };


### PR DESCRIPTION
This PR updates bsapacker so archive creation can use a game-provided GameArchiveHandler when the active game does not expose MO2’s built-in DataArchives capability.

Behavior after this change:

- If the active game exposes DataArchives, the existing Bethesda/libbsarch packer path remains unchanged
- Otherwise, if the active game exposes GameArchiveHandler, archive creation is delegated to the game plugin
- If neither capability exists, the packer is hidden/unavailable for that game

Why:

- Archive creation for non-Bethesda formats should live in the game plugin that knows the format
- This keeps the stock Bethesda packer behavior intact while allowing other games to participate without extending libbsarch for unrelated formats

Implementation notes:

- Adds capability-based gating in ModContext
- Adds delegated archive-creation flow in BsaPackerWorker
- Preserves the built-in path for Bethesda games
- Avoids built-in override/dummy-plugin behavior on the delegated path
- Includes a repeated-run safety fix so the destination archive is replaced before repacking, preventing the output archive from Being packed into itself on subsequent runs

Tested with:

- Built-in Bethesda visibility/routing behavior
- Hidden state on unsupported games
- Downstream XnGine archive creation through GameArchiveHandler
- Repeated pack runs against the same destination archive
- MO2 2.5.2
- MO2 2.5.3-beta.2